### PR TITLE
Feature: Scheduled mails

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ We welcome contributions from the community. Feel free to open issues and submit
 
 Prerequisites: [Docker](https://www.docker.com/) and [Yarn](https://yarnpkg.com/)
 
-The application consists of two components. The first one is a PostgreSQL database that can be launched after installing docker via running `docker compose up -d` in the root directory.
+The application consists of two components. The first one is a PostgreSQL database that can be launched after installing docker via running `docker compose -f docker-compose.dev.yml up -d` in the root directory.
 
 Afterwards you can run the following commands to start the Next.js server that serves both the spa-frontend as well as the backend API using prisma as the ORM.
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -72,7 +72,7 @@ export default [...compat.extends("airbnb/hooks", "prettier"), {
 
         parserOptions: {
             project: "./tsconfig.json",
-            tsconfigRootDir: "/home/enterprize1/Code/phishy-mailbox",
+            tsconfigRootDir: "./",
         },
     },
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -16,6 +16,7 @@ model Email {
   body                 String
   allowExternalImages  Boolean              @default(false)
   backofficeIdentifier String
+	scheduledTime        Int                  @default(0)
   StudyEmail           StudyEmail[]
   ParticipationEmail   ParticipationEmail[]
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -16,7 +16,6 @@ model Email {
   body                 String
   allowExternalImages  Boolean              @default(false)
   backofficeIdentifier String
-  scheduledTime        Int                  @default(0)
   StudyEmail           StudyEmail[]
   ParticipationEmail   ParticipationEmail[]
 }
@@ -55,6 +54,7 @@ model ParticipationEmail {
   folder          Folder?                   @relation(fields: [folderId], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "participation_email_folder_id_folder_id_fk")
   events          ParticipationEmailEvent[]
   order           Int                       @default(0)
+  scheduledTime   Int                       @default(0)
 }
 
 model ParticipationEmailEvent {
@@ -102,6 +102,7 @@ model StudyEmail {
   emailId String @db.Uuid
   email   Email  @relation(fields: [emailId], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "study_email_email_id_email_id_fk")
   order   Int    @default(0)
+  scheduledTime Int @default(0)
 
   @@unique([studyId, emailId])
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -16,7 +16,7 @@ model Email {
   body                 String
   allowExternalImages  Boolean              @default(false)
   backofficeIdentifier String
-	scheduledTime        Int                  @default(0)
+  scheduledTime        Int                  @default(0)
   StudyEmail           StudyEmail[]
   ParticipationEmail   ParticipationEmail[]
 }

--- a/prisma/seed.js
+++ b/prisma/seed.js
@@ -38,6 +38,15 @@ async function main() {
           body: 'Dies ist eine Phishing-Mail <a href="https://example.com">Link</a>' + '<br />'.repeat(200),
           backofficeIdentifier: 'Phishing',
         },
+				{
+					senderMail: 'human@example.com',
+					senderName: 'Human',
+					subject: 'Scheduled mail',
+					headers: '',
+					body: 'Diese Mail wurde gescheduled, nach 5 Sekunden zu erscheinen.' + '<br />'.repeat(200),
+					backofficeIdentifier: 'Scheduled',
+					scheduledTime: 5,
+				},
       ],
     });
 

--- a/prisma/seed.js
+++ b/prisma/seed.js
@@ -38,15 +38,15 @@ async function main() {
           body: 'Dies ist eine Phishing-Mail <a href="https://example.com">Link</a>' + '<br />'.repeat(200),
           backofficeIdentifier: 'Phishing',
         },
-				{
-					senderMail: 'human@example.com',
-					senderName: 'Human',
-					subject: 'Scheduled mail',
-					headers: '',
-					body: 'Diese Mail wurde gescheduled, nach 5 Sekunden zu erscheinen.' + '<br />'.repeat(200),
-					backofficeIdentifier: 'Scheduled',
-					scheduledTime: 5,
-				},
+        {
+          senderMail: 'human@example.com',
+          senderName: 'Human',
+          subject: 'Scheduled mail',
+          headers: '',
+          body: 'Diese Mail wurde gescheduled, nach 5 Sekunden zu erscheinen.' + '<br />'.repeat(200),
+          backofficeIdentifier: 'Scheduled',
+          scheduledTime: 5,
+        },
       ],
     });
 
@@ -88,6 +88,9 @@ async function main() {
               },
               {
                 emailId: emails.find((e) => e.backofficeIdentifier === 'Phishing').id,
+              },
+              {
+                emailId: emails.find((e) => e.backofficeIdentifier === 'Scheduled').id,
               },
             ],
           },

--- a/prisma/seed.js
+++ b/prisma/seed.js
@@ -45,7 +45,6 @@ async function main() {
           headers: '',
           body: 'Diese Mail wurde gescheduled, nach 5 Sekunden zu erscheinen.' + '<br />'.repeat(200),
           backofficeIdentifier: 'Scheduled',
-          scheduledTime: 5,
         },
       ],
     });
@@ -91,6 +90,7 @@ async function main() {
               },
               {
                 emailId: emails.find((e) => e.backofficeIdentifier === 'Scheduled').id,
+                scheduledTime: 5,
               },
             ],
           },

--- a/src/app/(notloggedin)/[code]/page.tsx
+++ b/src/app/(notloggedin)/[code]/page.tsx
@@ -99,24 +99,32 @@ const SingleEmail: FC<{
     id: email.id,
     disabled: disableDragging,
   });
+  const [scheduledTime, setScheduledTime] = useState<number>(email.email.scheduledTime);
 
-  return (
-    <button
-      type='button'
-      onClick={setAsCurrentEmail}
-      className={twMerge(
-        'flex w-full flex-col border-l-4 px-2 py-2 text-left text-sm hover:!border-l-gray-400',
-        isCurrentEmail ? 'bg-blue-100' : 'bg-gray-50 hover:bg-gray-100',
-        isDragging && 'opacity-0',
-      )}
-      ref={setNodeRef}
-      {...listeners}
-      {...attributes}
-    >
-      <div className='w-full truncate'>{email.email.senderName}</div>
-      <div className={clsx('w-full truncate')}>{email.email.subject}</div>
-    </button>
-  );
+  if (scheduledTime === 0) {
+    return (
+      <button
+        type='button'
+        onClick={setAsCurrentEmail}
+        className={twMerge(
+          'flex w-full flex-col border-l-4 px-2 py-2 text-left text-sm hover:!border-l-gray-400',
+          isCurrentEmail ? 'bg-blue-100' : 'bg-gray-50 hover:bg-gray-100',
+          isDragging && 'opacity-0',
+        )}
+        ref={setNodeRef}
+        {...listeners}
+        {...attributes}
+      >
+        <div className='w-full truncate'>{email.email.senderName}</div>
+        <div className={clsx('w-full truncate')}>{email.email.subject}</div>
+      </button>
+    );
+  } else {
+    setTimeout(() => {
+      setScheduledTime(0);
+    }, scheduledTime * 1000);
+    return;
+  }
 };
 
 const Emails: FC<{
@@ -467,6 +475,7 @@ export default function Run({params: {code}}: {params: {code: string}}) {
             allowExternalImages: false,
             backofficeIdentifier: '',
             headers: '',
+            scheduledTime: 0,
           },
         },
       ];

--- a/src/app/(notloggedin)/[code]/page.tsx
+++ b/src/app/(notloggedin)/[code]/page.tsx
@@ -102,11 +102,11 @@ const SingleEmail: FC<{
   });
   const now = new Date();
   const msSinceStart = startedAt ? now.getTime() - startedAt.getTime() : 0;
-  const [visible, setVisible] = useState<boolean>(msSinceStart >= email.email.scheduledTime * 1000);
+  const [visible, setVisible] = useState<boolean>(msSinceStart >= email.scheduledTime * 1000);
 
   useEffect(() => {
     if (!visible && startedAt) {
-      const delay = email.email.scheduledTime * 1000 - msSinceStart;
+      const delay = email.scheduledTime * 1000 - msSinceStart;
       if (delay > 0) {
         const timer = setTimeout(() => {
           setVisible(true);
@@ -116,7 +116,7 @@ const SingleEmail: FC<{
         setVisible(true);
       }
     }
-  }, [visible, startedAt, email.email.scheduledTime, msSinceStart]);
+  }, [visible, startedAt, email.scheduledTime, msSinceStart]);
 
   if (!visible) {
     return null;
@@ -453,6 +453,7 @@ export default function Run({params: {code}}: {params: {code: string}}) {
           emailId: introductionEmailId,
           folderId: null,
           participationId: data.id,
+          scheduledTime: 0,
           email: {
             id: introductionEmailId,
             senderMail: '',
@@ -491,7 +492,6 @@ export default function Run({params: {code}}: {params: {code: string}}) {
             allowExternalImages: false,
             backofficeIdentifier: '',
             headers: '',
-            scheduledTime: 0,
           },
         },
       ];

--- a/src/app/(notloggedin)/[code]/page.tsx
+++ b/src/app/(notloggedin)/[code]/page.tsx
@@ -101,37 +101,44 @@ const SingleEmail: FC<{
     disabled: disableDragging,
   });
   const now = new Date();
-  const msSinceStart = startedAt ? now - startedAt : 0;
+  const msSinceStart = startedAt ? now.getTime() - startedAt.getTime() : 0;
   const [visible, setVisible] = useState<boolean>(msSinceStart >= email.email.scheduledTime * 1000);
-  console.log(msSinceStart);
 
-  if (visible) {
-    return (
-      <button
-        type='button'
-        onClick={setAsCurrentEmail}
-        className={twMerge(
-          'flex w-full flex-col border-l-4 px-2 py-2 text-left text-sm hover:!border-l-gray-400',
-          isCurrentEmail ? 'bg-blue-100' : 'bg-gray-50 hover:bg-gray-100',
-          isDragging && 'opacity-0',
-        )}
-        ref={setNodeRef}
-        {...listeners}
-        {...attributes}
-      >
-        <div className='w-full truncate'>{email.email.senderName}</div>
-        <div className={clsx('w-full truncate')}>{email.email.subject}</div>
-      </button>
-    );
-  } else {
-    setTimeout(
-      () => {
+  useEffect(() => {
+    if (!visible && startedAt) {
+      const delay = email.email.scheduledTime * 1000 - msSinceStart;
+      if (delay > 0) {
+        const timer = setTimeout(() => {
+          setVisible(true);
+        }, delay);
+        return () => clearTimeout(timer);
+      } else {
         setVisible(true);
-      },
-      email.email.scheduledTime * 1000 - msSinceStart,
-    );
-    return;
+      }
+    }
+  }, [visible, startedAt, email.email.scheduledTime, msSinceStart]);
+
+  if (!visible) {
+    return null;
   }
+
+  return (
+    <button
+      type='button'
+      onClick={setAsCurrentEmail}
+      className={twMerge(
+        'flex w-full flex-col border-l-4 px-2 py-2 text-left text-sm hover:!border-l-gray-400',
+        isCurrentEmail ? 'bg-blue-100' : 'bg-gray-50 hover:bg-gray-100',
+        isDragging && 'opacity-0',
+      )}
+      ref={setNodeRef}
+      {...listeners}
+      {...attributes}
+    >
+      <div className='w-full truncate'>{email.email.senderName}</div>
+      <div className={clsx('w-full truncate')}>{email.email.subject}</div>
+    </button>
+  );
 };
 
 const Emails: FC<{

--- a/src/app/admin/(loggedin)/emails/[id]/page.tsx
+++ b/src/app/admin/(loggedin)/emails/[id]/page.tsx
@@ -64,6 +64,7 @@ export default function Page({params: {id}}: {params: {id: string}}) {
       senderName: '',
       allowExternalImages: false,
       backofficeIdentifier: '',
+			scheduledTime: 0,
     },
   });
   const addMail = trpc.email.add.useMutation();
@@ -115,7 +116,10 @@ export default function Page({params: {id}}: {params: {id: string}}) {
       </Headline>
       <Form builder={builder} onSubmit={onSubmit}>
         <div className='my-2 flex flex-col gap-x-8 gap-y-2'>
-          <InputField label={t('identifier')} on={builder.fields.backofficeIdentifier} rules={{required: true}} />
+					<div className='flex gap-4'>
+						<InputField label={t('identifier')} on={builder.fields.backofficeIdentifier} rules={{required: true}} className='mr-2' />
+						<InputField label={t('scheduledTime')} on={builder.fields.scheduledTime} rules={{min: 0}} />
+					</div>
           <fieldset className='flex flex-wrap'>
             <legend className='text-md font-semibold'>{t('sender')}</legend>
             <div className='flex gap-4'>

--- a/src/app/admin/(loggedin)/emails/[id]/page.tsx
+++ b/src/app/admin/(loggedin)/emails/[id]/page.tsx
@@ -83,6 +83,9 @@ export default function Page({params: {id}}: {params: {id: string}}) {
   }, [getMail.data, isCreate]);
 
   const onSubmit = async (data: Partial<Email>) => {
+    // convert from string to number
+    data.scheduledTime = +data.scheduledTime;
+
     try {
       if (isCreate) {
         await addMail.mutateAsync({email: data as Required<Email>});
@@ -123,7 +126,7 @@ export default function Page({params: {id}}: {params: {id: string}}) {
               rules={{required: true}}
               className='mr-2'
             />
-            <InputField label={t('scheduledTime')} on={builder.fields.scheduledTime} rules={{min: 0}} />
+            <InputField type='number' label={t('scheduledTime')} on={builder.fields.scheduledTime} rules={{min: 0}} />
           </div>
           <fieldset className='flex flex-wrap'>
             <legend className='text-md font-semibold'>{t('sender')}</legend>

--- a/src/app/admin/(loggedin)/emails/[id]/page.tsx
+++ b/src/app/admin/(loggedin)/emails/[id]/page.tsx
@@ -82,9 +82,6 @@ export default function Page({params: {id}}: {params: {id: string}}) {
   }, [getMail.data, isCreate]);
 
   const onSubmit = async (data: Partial<Email>) => {
-    // convert from string to number
-    data.scheduledTime = +data.scheduledTime;
-
     try {
       if (isCreate) {
         await addMail.mutateAsync({email: data as Required<Email>});

--- a/src/app/admin/(loggedin)/emails/[id]/page.tsx
+++ b/src/app/admin/(loggedin)/emails/[id]/page.tsx
@@ -64,7 +64,7 @@ export default function Page({params: {id}}: {params: {id: string}}) {
       senderName: '',
       allowExternalImages: false,
       backofficeIdentifier: '',
-			scheduledTime: 0,
+      scheduledTime: 0,
     },
   });
   const addMail = trpc.email.add.useMutation();
@@ -116,10 +116,15 @@ export default function Page({params: {id}}: {params: {id: string}}) {
       </Headline>
       <Form builder={builder} onSubmit={onSubmit}>
         <div className='my-2 flex flex-col gap-x-8 gap-y-2'>
-					<div className='flex gap-4'>
-						<InputField label={t('identifier')} on={builder.fields.backofficeIdentifier} rules={{required: true}} className='mr-2' />
-						<InputField label={t('scheduledTime')} on={builder.fields.scheduledTime} rules={{min: 0}} />
-					</div>
+          <div className='flex gap-4'>
+            <InputField
+              label={t('identifier')}
+              on={builder.fields.backofficeIdentifier}
+              rules={{required: true}}
+              className='mr-2'
+            />
+            <InputField label={t('scheduledTime')} on={builder.fields.scheduledTime} rules={{min: 0}} />
+          </div>
           <fieldset className='flex flex-wrap'>
             <legend className='text-md font-semibold'>{t('sender')}</legend>
             <div className='flex gap-4'>

--- a/src/app/admin/(loggedin)/emails/[id]/page.tsx
+++ b/src/app/admin/(loggedin)/emails/[id]/page.tsx
@@ -64,7 +64,6 @@ export default function Page({params: {id}}: {params: {id: string}}) {
       senderName: '',
       allowExternalImages: false,
       backofficeIdentifier: '',
-      scheduledTime: 0,
     },
   });
   const addMail = trpc.email.add.useMutation();
@@ -119,15 +118,7 @@ export default function Page({params: {id}}: {params: {id: string}}) {
       </Headline>
       <Form builder={builder} onSubmit={onSubmit}>
         <div className='my-2 flex flex-col gap-x-8 gap-y-2'>
-          <div className='flex gap-4'>
-            <InputField
-              label={t('identifier')}
-              on={builder.fields.backofficeIdentifier}
-              rules={{required: true}}
-              className='mr-2'
-            />
-            <InputField type='number' label={t('scheduledTime')} on={builder.fields.scheduledTime} rules={{min: 0}} />
-          </div>
+          <InputField label={t('identifier')} on={builder.fields.backofficeIdentifier} rules={{required: true}} className='mr-2' />
           <fieldset className='flex flex-wrap'>
             <legend className='text-md font-semibold'>{t('sender')}</legend>
             <div className='flex gap-4'>

--- a/src/app/admin/(loggedin)/emails/[id]/page.tsx
+++ b/src/app/admin/(loggedin)/emails/[id]/page.tsx
@@ -118,7 +118,12 @@ export default function Page({params: {id}}: {params: {id: string}}) {
       </Headline>
       <Form builder={builder} onSubmit={onSubmit}>
         <div className='my-2 flex flex-col gap-x-8 gap-y-2'>
-          <InputField label={t('identifier')} on={builder.fields.backofficeIdentifier} rules={{required: true}} className='mr-2' />
+          <InputField
+            label={t('identifier')}
+            on={builder.fields.backofficeIdentifier}
+            rules={{required: true}}
+            className='mr-2'
+          />
           <fieldset className='flex flex-wrap'>
             <legend className='text-md font-semibold'>{t('sender')}</legend>
             <div className='flex gap-4'>

--- a/src/app/admin/(loggedin)/studies/[id]/page.tsx
+++ b/src/app/admin/(loggedin)/studies/[id]/page.tsx
@@ -157,6 +157,10 @@ export default function PageUpsert({params: {id}}: {params: {id: string}}) {
   }, [getStudy.data, isCreate]);
 
   const onSubmit = async (data: Study & {folder: FormFolder[]; email: FormEmail[]}) => {
+    // convert from string to number
+    for (let i = 0; i < data.email.length; i++) {
+      data.email[i].scheduledTime = +data.email[i].scheduledTime;
+    }
     try {
       if (isCreate) {
         await addStudy.mutateAsync({

--- a/src/app/admin/(loggedin)/studies/[id]/page.tsx
+++ b/src/app/admin/(loggedin)/studies/[id]/page.tsx
@@ -320,6 +320,7 @@ export default function PageUpsert({params: {id}}: {params: {id: string}}) {
           defaultValue={{
             emailId: null as any, // eslint-disable-line @typescript-eslint/no-explicit-any
             order: builder.fields.email.$useFieldArray().fields.length,
+            scheduledTime: 0,
           }}
           reorder
         >
@@ -334,6 +335,8 @@ export default function PageUpsert({params: {id}}: {params: {id: string}}) {
                 label={t('email')}
                 on={on.emailId}
               />
+
+              <InputField type='number' label={t('scheduledTime')} on={on.scheduledTime} rules={{min: 0}} />
             </div>
           )}
         </MasterDetailView>

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -62,7 +62,7 @@
         "emails": "E-Mails",
         "create": "Anlegen",
         "deleteConfirm": "Sind Sie sich sicher, dass Sie diese E-Mail löschen möchten?",
-				"deletedSuccess": "E-Mail erfolgreich gelöscht",
+        "deletedSuccess": "E-Mail erfolgreich gelöscht",
         "deleteError": "E-Mail konnte nicht gelöscht werden. Wird sie in einer Studie genutzt?",
         "uploadMultiple": "Mehrere E-Mails hochladen",
         "uploadError": "Fehler beim Hochladen der E-Mail. Ist die Datei im .eml Format?",

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -75,7 +75,6 @@
         "createEmailManually": "E-Mail manuell anlegen",
         "editEmailManually": "E-Mail manuell bearbeiten",
         "identifier": "Identifizierer im Backoffice",
-        "scheduledTime": "Zeitverzögerung in Sekunden",
         "sender": "Absender",
         "senderEmail": "E-Mail",
         "senderName": "Name",
@@ -142,6 +141,7 @@
         "htmlIsAllowed": "HTML ist erlaubt",
         "yes": "Ja, Einwilligung vor der Teilnahme abfragen",
         "no": "Nein, keine Einwilligung vor der Teilnahme abfragen",
+        "scheduledTime": "Zeitverzögerung in Sekunden",
 
         "participants": {
           "created": "Erstellt",

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -75,7 +75,7 @@
         "createEmailManually": "E-Mail manuell anlegen",
         "editEmailManually": "E-Mail manuell bearbeiten",
         "identifier": "Identifizierer im Backoffice",
-				"scheduledTime": "Zeitverzögerung in Sekunden",
+        "scheduledTime": "Zeitverzögerung in Sekunden",
         "sender": "Absender",
         "senderEmail": "E-Mail",
         "senderName": "Name",

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -75,6 +75,7 @@
         "createEmailManually": "E-Mail manuell anlegen",
         "editEmailManually": "E-Mail manuell bearbeiten",
         "identifier": "Identifizierer im Backoffice",
+				"scheduledTime": "Zeitverzögerung in Sekunden",
         "sender": "Absender",
         "senderEmail": "E-Mail",
         "senderName": "Name",

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -62,7 +62,7 @@
         "emails": "E-Mails",
         "create": "Anlegen",
         "deleteConfirm": "Sind Sie sich sicher, dass Sie diese E-Mail löschen möchten?",
-        "deleteSuccess": "E-Mail erfolgreich gelöscht",
+				"deletedSuccess": "E-Mail erfolgreich gelöscht",
         "deleteError": "E-Mail konnte nicht gelöscht werden. Wird sie in einer Studie genutzt?",
         "uploadMultiple": "Mehrere E-Mails hochladen",
         "uploadError": "Fehler beim Hochladen der E-Mail. Ist die Datei im .eml Format?",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -75,7 +75,6 @@
         "createEmailManually": "Create Email Manually",
         "editEmailManually": "Edit Email Manually",
         "identifier": "Identifier in the Back Office",
-        "scheduledTime": "Delay in seconds",
         "sender": "Sender",
         "senderEmail": "Email",
         "senderName": "Name",
@@ -142,6 +141,7 @@
         "htmlIsAllowed": "HTML is allowed",
         "yes": "Yes, ask for consent before participation",
         "no": "No, do not ask for consent before participation",
+        "scheduledTime": "Delay in seconds",
         "participants": {
           "created": "Created",
           "code": "Code",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -75,7 +75,7 @@
         "createEmailManually": "Create Email Manually",
         "editEmailManually": "Edit Email Manually",
         "identifier": "Identifier in the Back Office",
-				"scheduledTime": "Delay in seconds",
+        "scheduledTime": "Delay in seconds",
         "sender": "Sender",
         "senderEmail": "Email",
         "senderName": "Name",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -75,6 +75,7 @@
         "createEmailManually": "Create Email Manually",
         "editEmailManually": "Edit Email Manually",
         "identifier": "Identifier in the Back Office",
+				"scheduledTime": "Delay in seconds",
         "sender": "Sender",
         "senderEmail": "Email",
         "senderName": "Name",

--- a/src/server/api/routers/email.ts
+++ b/src/server/api/routers/email.ts
@@ -30,7 +30,6 @@ export const emailRouter = createTRPCRouter({
         body: parsed.html || parsed.textAsHtml,
         allowExternalImages: false,
         backofficeIdentifier: `${parsed.subject} / ${parsed.from.value[0].name}`,
-        scheduledTime: 0,
       };
     }),
   add: protectedProcedure
@@ -44,7 +43,6 @@ export const emailRouter = createTRPCRouter({
           body: z.string(),
           allowExternalImages: z.boolean(),
           backofficeIdentifier: z.string(),
-          scheduledTime: z.number(),
         }),
       }),
     )
@@ -72,7 +70,6 @@ export const emailRouter = createTRPCRouter({
           body: z.string(),
           allowExternalImages: z.boolean(),
           backofficeIdentifier: z.string(),
-          scheduledTime: z.number(),
         }),
       }),
     )

--- a/src/server/api/routers/email.ts
+++ b/src/server/api/routers/email.ts
@@ -30,6 +30,7 @@ export const emailRouter = createTRPCRouter({
         body: parsed.html || parsed.textAsHtml,
         allowExternalImages: false,
         backofficeIdentifier: `${parsed.subject} / ${parsed.from.value[0].name}`,
+        scheduledTime: 0,
       };
     }),
   add: protectedProcedure
@@ -43,6 +44,7 @@ export const emailRouter = createTRPCRouter({
           body: z.string(),
           allowExternalImages: z.boolean(),
           backofficeIdentifier: z.string(),
+          scheduledTime: z.number(),
         }),
       }),
     )
@@ -70,6 +72,7 @@ export const emailRouter = createTRPCRouter({
           body: z.string(),
           allowExternalImages: z.boolean(),
           backofficeIdentifier: z.string(),
+          scheduledTime: z.number(),
         }),
       }),
     )

--- a/src/server/api/routers/participation.ts
+++ b/src/server/api/routers/participation.ts
@@ -116,6 +116,7 @@ export const participationRouter = createTRPCRouter({
               data: participation.study.email.map((email) => ({
                 emailId: email.email.id,
                 order: email.order,
+                scheduledTime: email.scheduledTime,
               })),
             },
           },

--- a/src/server/api/routers/study.ts
+++ b/src/server/api/routers/study.ts
@@ -45,6 +45,7 @@ export const studyRouter = createTRPCRouter({
               z.object({
                 emailId: z.string().nullable(),
                 order: z.number().optional(),
+                scheduledTime: z.number().optional(),
               }),
             ),
           }),
@@ -72,6 +73,7 @@ export const studyRouter = createTRPCRouter({
                 .map((f, i) => ({
                   emailId: f.emailId,
                   order: i,
+                  scheduledTime: 0,
                 })),
             },
           },
@@ -115,6 +117,7 @@ export const studyRouter = createTRPCRouter({
                 id: z.string().uuid().optional(),
                 emailId: z.string().uuid(),
                 order: z.number(),
+                scheduledTime: z.number(),
               }),
             ),
           }),
@@ -189,6 +192,7 @@ export const studyRouter = createTRPCRouter({
                   data: {
                     emailId: f.emailId,
                     order: email.findIndex((e) => e.id === f.id),
+                    scheduledTime: f.scheduledTime,
                   },
                 })),
               createMany: {
@@ -197,6 +201,7 @@ export const studyRouter = createTRPCRouter({
                   .map((f) => ({
                     emailId: f.emailId,
                     order: email.findIndex((e) => e.id === f.id),
+                    scheduledTime: f.scheduledTime,
                   })),
               },
             },

--- a/src/server/api/routers/study.ts
+++ b/src/server/api/routers/study.ts
@@ -69,11 +69,11 @@ export const studyRouter = createTRPCRouter({
           email: {
             createMany: {
               data: email
-                .filter((e): e is {emailId: string} => !!e.emailId)
+                .filter((e): e is typeof e & {emailId: string} => !!e.emailId)
                 .map((f, i) => ({
                   emailId: f.emailId,
                   order: i,
-                  scheduledTime: 0,
+                  scheduledTime: f.scheduledTime ?? 0,
                 })),
             },
           },


### PR DESCRIPTION
# Feature description

Emails can now be scheduled to appear a given number of seconds after the start. Technically, these emails are already in the Inbox, they are just invisible until the given delay elapsed. The delay can be set in the email editor.

# Implementation details

The Email relation in prisma now has an additional property `scheduledTime`, which defaults to 0.
The front end checks for every email if `scheduledTime` is greater than 0, and if so, hides the button for that email, calculates when it should be visible based on the `startedAt` time, and starts a timeout with `setTimeout()` that shows the button after the remaining time elapsed. Because it relies on the absolute start time, behavior is consistent across page reloads.

# Other changes

 - `eslint.config.mjs` contained an absolute path, which was replaced by a relative path to allow linting on other developers machines.
 - Fixed typo in german `translation.json` so the front end now uses the german translation for `deletedSuccess`