### PR TITLE
Allow participants to reply to emails

### DIFF
--- a/src/app/(notloggedin)/[code]/page.tsx
+++ b/src/app/(notloggedin)/[code]/page.tsx
@@ -661,7 +661,17 @@ export default function Run({params: {code}}: {params: {code: string}}) {
                       } as EMailOpenReplyEvent,
                     });
                   }}
-                  onSendReply={() => {
+                  onSendReply={(message) => {
+                    trackEventMutation.mutate({
+                      participationId: data.id,
+                      participationEmailId: currentEmail.id,
+                      event: {
+                        type: 'email-send-reply',
+                        message: message,
+                      } as EMailSendReplyEvent,
+                    });
+                  }}
+                  onAbortReply={() => {
                     trackEventMutation.mutate({
                       participationId: data.id,
                       participationEmailId: currentEmail.id,

--- a/src/app/(notloggedin)/[code]/page.tsx
+++ b/src/app/(notloggedin)/[code]/page.tsx
@@ -25,7 +25,7 @@ import {
   EMailViewEvent,
   EMailViewExternalImagesEvent,
   EMailViewDetailsEvent,
-  EmailWriteReplyEvent,
+	EmailOpenReplyEvent,
   EmailSendReplyEvent,
 } from '~/server/api/routers/participationEvents';
 import {useTranslation} from 'react-i18next';
@@ -652,13 +652,13 @@ export default function Run({params: {code}}: {params: {code: string}}) {
                       } as EMailViewDetailsEvent,
                     });
                   }}
-                  onWriteReply={() => {
+									onOpenReply={() => {
                     trackEventMutation.mutate({
                       participationId: data.id,
                       participationEmailId: currentEmail.id,
                       event: {
-                        type: 'email-write-reply',
-                      } as EMailWriteReplyEvent,
+												type: 'email-open-reply',
+											} as EMailOpenReplyEvent,
                     });
                   }}
                   onSendReply={() => {

--- a/src/app/(notloggedin)/[code]/page.tsx
+++ b/src/app/(notloggedin)/[code]/page.tsx
@@ -25,7 +25,7 @@ import {
   EMailViewEvent,
   EMailViewExternalImagesEvent,
   EMailViewDetailsEvent,
-	EmailOpenReplyEvent,
+  EmailOpenReplyEvent,
   EmailSendReplyEvent,
 } from '~/server/api/routers/participationEvents';
 import {useTranslation} from 'react-i18next';
@@ -652,13 +652,13 @@ export default function Run({params: {code}}: {params: {code: string}}) {
                       } as EMailViewDetailsEvent,
                     });
                   }}
-									onOpenReply={() => {
+                  onOpenReply={() => {
                     trackEventMutation.mutate({
                       participationId: data.id,
                       participationEmailId: currentEmail.id,
                       event: {
-												type: 'email-open-reply',
-											} as EMailOpenReplyEvent,
+                        type: 'email-open-reply',
+                      } as EMailOpenReplyEvent,
                     });
                   }}
                   onSendReply={() => {

--- a/src/app/(notloggedin)/[code]/page.tsx
+++ b/src/app/(notloggedin)/[code]/page.tsx
@@ -25,6 +25,8 @@ import {
   EMailViewEvent,
   EMailViewExternalImagesEvent,
   EMailViewDetailsEvent,
+  EmailWriteReplyEvent,
+  EmailSendReplyEvent,
 } from '~/server/api/routers/participationEvents';
 import {useTranslation} from 'react-i18next';
 import {TimerMode} from '.prisma/client';
@@ -648,6 +650,24 @@ export default function Run({params: {code}}: {params: {code: string}}) {
                       event: {
                         type: 'email-details-view',
                       } as EMailViewDetailsEvent,
+                    });
+                  }}
+                  onWriteReply={() => {
+                    trackEventMutation.mutate({
+                      participationId: data.id,
+                      participationEmailId: currentEmail.id,
+                      event: {
+                        type: 'email-write-reply',
+                      } as EMailWriteReplyEvent,
+                    });
+                  }}
+                  onSendReply={() => {
+                    trackEventMutation.mutate({
+                      participationId: data.id,
+                      participationEmailId: currentEmail.id,
+                      event: {
+                        type: 'email-send-reply',
+                      } as EMailSendReplyEvent,
                     });
                   }}
                   onViewExternalImages={() => {

--- a/src/app/(notloggedin)/[code]/page.tsx
+++ b/src/app/(notloggedin)/[code]/page.tsx
@@ -676,8 +676,8 @@ export default function Run({params: {code}}: {params: {code: string}}) {
                       participationId: data.id,
                       participationEmailId: currentEmail.id,
                       event: {
-                        type: 'email-send-reply',
-                      } as EMailSendReplyEvent,
+                        type: 'email-abort-reply',
+                      } as EMailAbortReplyEvent,
                     });
                   }}
                   onViewExternalImages={() => {

--- a/src/app/(notloggedin)/[code]/page.tsx
+++ b/src/app/(notloggedin)/[code]/page.tsx
@@ -25,8 +25,9 @@ import {
   EMailViewEvent,
   EMailViewExternalImagesEvent,
   EMailViewDetailsEvent,
-  EmailOpenReplyEvent,
-  EmailSendReplyEvent,
+  EMailOpenReplyEvent,
+  EMailSendReplyEvent,
+  EMailAbortReplyEvent,
 } from '~/server/api/routers/participationEvents';
 import {useTranslation} from 'react-i18next';
 import {TimerMode} from '.prisma/client';

--- a/src/components/email-display.tsx
+++ b/src/components/email-display.tsx
@@ -56,9 +56,9 @@ const EmailDisplayDetails: FC<{headers?: string; onViewDetails?: () => void}> = 
   );
 };
 
-const EmailDisplayReply: FC<{onWriteReply?: () => void}> = ({onWriteReply}) => {
+const EmailDisplayReply: FC<{onWriteReply?: () => void; onSendReply?: () => void}> = ({onWriteReply, onSendReply}) => {
   const {t} = useTranslation(undefined, {keyPrefix: 'components.emailDisplay.reply'});
-  const builder = useFormBuilder<{subject: string; message: string}>({defaultValues: {subject: 'RE', message: ''}});
+  const builder = useFormBuilder<{subject: string; message: string}>({defaultValues: {subject: 'Re: ', message: ''}});
 
   return (
     <Dialog.Root>
@@ -75,7 +75,7 @@ const EmailDisplayReply: FC<{onWriteReply?: () => void}> = ({onWriteReply}) => {
         <Dialog.Content className='fixed left-1/2 top-1/2 z-50 flex max-h-[85vh] max-w-[85vw] -translate-x-1/2 -translate-y-1/2 flex-col bg-white p-6'>
           <Dialog.Title className='m-0 font-bold'>{t('composeNewMessage')}</Dialog.Title>
           <Dialog.Description className='flex-shrink overflow-y-scroll whitespace-pre-wrap'>
-            <Form builder={builder} onSubmit={async () => {}}>
+  <Form builder={builder} onSubmit={async () => onSendReply?.()}>
               <div className='my-2 flex flex-col gap-x-8 gap-y-2'>
                 <InputField label={t('subject')} on={builder.fields.subject} />
               </div>
@@ -109,6 +109,7 @@ export default function EmailDisplay({
   onHover,
   onViewDetails,
   onWriteReply,
+  onSendReply,
   onViewExternalImages,
 }: {
   email: Partial<EmailWithFunctionAsBody>;
@@ -120,6 +121,7 @@ export default function EmailDisplay({
   onHover?: (href: string, text: string) => void;
   onViewDetails?: () => void;
   onWriteReply?: () => void;
+  onSendReply?: () => void;
   onViewExternalImages?: () => void;
 }) {
   const {t} = useTranslation(undefined, {keyPrefix: 'components.emailDisplay'});

--- a/src/components/email-display.tsx
+++ b/src/components/email-display.tsx
@@ -65,7 +65,7 @@ const EmailDisplayReply: FC<{onOpenReply?: () => void; onSendReply?: () => void}
       <Dialog.Trigger asChild>
         <button
           className='self-center rounded-sm border bg-gray-100 px-2 py-1 hover:bg-gray-200'
-					onClick={() => onOpenReply?.()}
+          onClick={() => onOpenReply?.()}
         >
           {t('reply')}
         </button>
@@ -74,20 +74,18 @@ const EmailDisplayReply: FC<{onOpenReply?: () => void; onSendReply?: () => void}
         <Dialog.Overlay className='fixed inset-0 z-50 bg-black/40' />
         <Dialog.Content className='fixed left-1/2 top-1/2 z-50 flex max-h-[85vh] max-w-[85vw] -translate-x-1/2 -translate-y-1/2 flex-col bg-white p-6'>
           <Dialog.Title className='m-0 font-bold'>{t('composeNewMessage')}</Dialog.Title>
-          <Dialog.Description className='flex-shrink overflow-y-scroll whitespace-pre-wrap'>
-  <Form builder={builder} onSubmit={async () => onSendReply?.()}>
-              <div className='my-2 flex flex-col gap-x-8 gap-y-2'>
-                <InputField label={t('subject')} on={builder.fields.subject} />
-              </div>
-              <CodeTextarea label={t('content')} on={builder.fields.message} />
-              <button
-                type='submit'
-                className='mt-4 flex justify-center rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600'
-              >
-                {t('send')}
-              </button>
-            </Form>
-          </Dialog.Description>
+          <Form builder={builder} onSubmit={() => onSendReply?.()}>
+            <div className='my-2 flex flex-col gap-x-8 gap-y-2'>
+              <InputField label={t('subject')} on={builder.fields.subject} />
+            </div>
+            <CodeTextarea label={t('content')} on={builder.fields.message} />
+            <button
+              type='submit'
+              className='mt-4 flex justify-center rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600'
+            >
+              {t('send')}
+            </button>
+          </Form>
           <Dialog.Close asChild>
             <button className='mt-4 flex justify-center self-end rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600'>
               {t('close')}
@@ -108,7 +106,7 @@ export default function EmailDisplay({
   onClick,
   onHover,
   onViewDetails,
-	onOpenReply,
+  onOpenReply,
   onSendReply,
   onViewExternalImages,
 }: {
@@ -120,7 +118,7 @@ export default function EmailDisplay({
   onClick?: (href: string, text: string) => void;
   onHover?: (href: string, text: string) => void;
   onViewDetails?: () => void;
-	onOpenReply?: () => void;
+  onOpenReply?: () => void;
   onSendReply?: () => void;
   onViewExternalImages?: () => void;
 }) {
@@ -249,7 +247,7 @@ export default function EmailDisplay({
             <div>{t('to')}</div>
           </div>
           <div>
-						<EmailDisplayReply onOpenReply={onOpenReply} onSendReply={onSendReply} />
+            <EmailDisplayReply onOpenReply={onOpenReply} onSendReply={onSendReply} />
             <EmailDisplayDetails headers={email.headers} onViewDetails={onViewDetails} />
           </div>
         </div>

--- a/src/components/email-display.tsx
+++ b/src/components/email-display.tsx
@@ -5,6 +5,10 @@ import {FC, ReactNode, SyntheticEvent, useCallback, useMemo, useState} from 'rea
 import * as Dialog from '@radix-ui/react-dialog';
 import {useTranslation} from 'react-i18next';
 import {InformationCircleIcon} from '@heroicons/react/24/solid';
+import InputField from '~/components/forms/fields/InputField';
+import CodeTextarea from '~/components/forms/fields/CodeTextarea';
+import Form from '~/components/forms/Form';
+import {useFormBuilder} from '@atmina/formbuilder';
 
 export type EmailWithFunctionAsBody = Omit<Email, 'body'> & {body: (() => ReactNode) | Email['body'] | null};
 
@@ -52,6 +56,49 @@ const EmailDisplayDetails: FC<{headers?: string; onViewDetails?: () => void}> = 
   );
 };
 
+const EmailDisplayReply: FC<{onWriteReply?: () => void}> = ({onWriteReply}) => {
+  const {t} = useTranslation(undefined, {keyPrefix: 'components.emailDisplay.reply'});
+  const builder = useFormBuilder<{subject: string; message: string}>({defaultValues: {subject: 'RE', message: ''}});
+
+  return (
+    <Dialog.Root>
+      <Dialog.Trigger asChild>
+        <button
+          className='self-center rounded-sm border bg-gray-100 px-2 py-1 hover:bg-gray-200'
+          onClick={() => onWriteReply?.()}
+        >
+          {t('reply')}
+        </button>
+      </Dialog.Trigger>
+      <Dialog.Portal>
+        <Dialog.Overlay className='fixed inset-0 z-50 bg-black/40' />
+        <Dialog.Content className='fixed left-1/2 top-1/2 z-50 flex max-h-[85vh] max-w-[85vw] -translate-x-1/2 -translate-y-1/2 flex-col bg-white p-6'>
+          <Dialog.Title className='m-0 font-bold'>{t('composeNewMessage')}</Dialog.Title>
+          <Dialog.Description className='flex-shrink overflow-y-scroll whitespace-pre-wrap'>
+            <Form builder={builder} onSubmit={async () => {}}>
+              <div className='my-2 flex flex-col gap-x-8 gap-y-2'>
+                <InputField label={t('subject')} on={builder.fields.subject} />
+              </div>
+              <CodeTextarea label={t('content')} on={builder.fields.message} />
+              <button
+                type='submit'
+                className='mt-4 flex justify-center rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600'
+              >
+                {t('send')}
+              </button>
+            </Form>
+          </Dialog.Description>
+          <Dialog.Close asChild>
+            <button className='mt-4 flex justify-center self-end rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600'>
+              {t('close')}
+            </button>
+          </Dialog.Close>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+};
+
 export default function EmailDisplay({
   email,
   studyId,
@@ -61,6 +108,7 @@ export default function EmailDisplay({
   onClick,
   onHover,
   onViewDetails,
+  onWriteReply,
   onViewExternalImages,
 }: {
   email: Partial<EmailWithFunctionAsBody>;
@@ -71,6 +119,7 @@ export default function EmailDisplay({
   onClick?: (href: string, text: string) => void;
   onHover?: (href: string, text: string) => void;
   onViewDetails?: () => void;
+  onWriteReply?: () => void;
   onViewExternalImages?: () => void;
 }) {
   const {t} = useTranslation(undefined, {keyPrefix: 'components.emailDisplay'});
@@ -197,7 +246,10 @@ export default function EmailDisplay({
             </div>
             <div>{t('to')}</div>
           </div>
-          <EmailDisplayDetails headers={email.headers} onViewDetails={onViewDetails} />
+          <div>
+            <EmailDisplayReply onViewDetails={onWriteReply} />
+            <EmailDisplayDetails headers={email.headers} onViewDetails={onViewDetails} />
+          </div>
         </div>
         {studyExternalImageMode === ExternalImageMode.ASK && !showExternalImages && (
           <div className='flex gap-4 bg-gray-50 px-4 py-2 items-center border-y'>

--- a/src/components/email-display.tsx
+++ b/src/components/email-display.tsx
@@ -56,7 +56,7 @@ const EmailDisplayDetails: FC<{headers?: string; onViewDetails?: () => void}> = 
   );
 };
 
-const EmailDisplayReply: FC<{onWriteReply?: () => void; onSendReply?: () => void}> = ({onWriteReply, onSendReply}) => {
+const EmailDisplayReply: FC<{onOpenReply?: () => void; onSendReply?: () => void}> = ({onOpenReply, onSendReply}) => {
   const {t} = useTranslation(undefined, {keyPrefix: 'components.emailDisplay.reply'});
   const builder = useFormBuilder<{subject: string; message: string}>({defaultValues: {subject: 'Re: ', message: ''}});
 
@@ -65,7 +65,7 @@ const EmailDisplayReply: FC<{onWriteReply?: () => void; onSendReply?: () => void
       <Dialog.Trigger asChild>
         <button
           className='self-center rounded-sm border bg-gray-100 px-2 py-1 hover:bg-gray-200'
-          onClick={() => onWriteReply?.()}
+					onClick={() => onOpenReply?.()}
         >
           {t('reply')}
         </button>
@@ -108,7 +108,7 @@ export default function EmailDisplay({
   onClick,
   onHover,
   onViewDetails,
-  onWriteReply,
+	onOpenReply,
   onSendReply,
   onViewExternalImages,
 }: {
@@ -120,7 +120,7 @@ export default function EmailDisplay({
   onClick?: (href: string, text: string) => void;
   onHover?: (href: string, text: string) => void;
   onViewDetails?: () => void;
-  onWriteReply?: () => void;
+	onOpenReply?: () => void;
   onSendReply?: () => void;
   onViewExternalImages?: () => void;
 }) {
@@ -249,7 +249,7 @@ export default function EmailDisplay({
             <div>{t('to')}</div>
           </div>
           <div>
-            <EmailDisplayReply onViewDetails={onWriteReply} />
+						<EmailDisplayReply onOpenReply={onOpenReply} onSendReply={onSendReply} />
             <EmailDisplayDetails headers={email.headers} onViewDetails={onViewDetails} />
           </div>
         </div>

--- a/src/components/email-display.tsx
+++ b/src/components/email-display.tsx
@@ -62,7 +62,7 @@ const EmailDisplayReply: FC<{
   onSendReply?: (message: string) => void;
   onAbortReply?: () => void;
 }> = ({subject, onOpenReply, onSendReply, onAbortReply}) => {
-  const [message, setMessage] = useState<string>("");
+  const [message, setMessage] = useState<string>('');
   const [open, setOpen] = useState<boolean>(false);
   const {t} = useTranslation(undefined, {keyPrefix: 'components.emailDisplay.reply'});
   const builder = useFormBuilder<{subject: string; message: string}>({

--- a/src/components/email-display.tsx
+++ b/src/components/email-display.tsx
@@ -93,7 +93,12 @@ const EmailDisplayReply: FC<{
             <div className='my-2 flex flex-col gap-x-8 gap-y-2'>
               <InputField label={t('subject')} on={builder.fields.subject} />
             </div>
-            <CodeTextarea label={t('content')} on={builder.fields.message} />
+            <CodeTextarea
+              label={t('content')}
+              on={builder.fields.message}
+              value={message}
+              onChange={(e) => setMessage(e.target.value)}
+            />
             <button
               type='submit'
               className='mt-4 flex-shrink justify-center rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600'

--- a/src/components/email-display.tsx
+++ b/src/components/email-display.tsx
@@ -62,7 +62,6 @@ const EmailDisplayReply: FC<{
   onSendReply?: (message: string) => void;
   onAbortReply?: () => void;
 }> = ({subject, onOpenReply, onSendReply, onAbortReply}) => {
-  const [message, setMessage] = useState<string>('');
   const [open, setOpen] = useState<boolean>(false);
   const {t} = useTranslation(undefined, {keyPrefix: 'components.emailDisplay.reply'});
   const builder = useFormBuilder<{subject: string; message: string}>({
@@ -85,8 +84,9 @@ const EmailDisplayReply: FC<{
           <Dialog.Title className='m-0 font-bold'>{t('composeNewMessage')}</Dialog.Title>
           <Form
             builder={builder}
-            onSubmit={() => {
-              onSendReply?.(message);
+            onSubmit={(data) => {
+              onSendReply?.(data.message);
+              builder.fields.message.$setValue("");
               setOpen(false);
             }}
           >
@@ -96,8 +96,6 @@ const EmailDisplayReply: FC<{
             <CodeTextarea
               label={t('content')}
               on={builder.fields.message}
-              value={message}
-              onChange={(e) => setMessage(e.target.value)}
             />
             <button
               type='submit'

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -201,6 +201,14 @@
         "messageDetails": "Nachrichtendetails",
         "close": "Schließen"
       },
+      "reply": {
+        "reply": "Antworten",
+        "composeNewMessage": "Neue Nachricht verfassen",
+        "subject": "Betreff",
+        "message": "Nachricht",
+        "send": "Abschicken",
+        "close": "Schließen"
+      },
       "imagesBlocked": "Bilder in dieser E-Mail wurden blockiert.",
       "showImages": "Bilder anzeigen"
     }

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -200,6 +200,14 @@
         "messageDetails": "Message Details",
         "close": "Close"
       },
+      "reply": {
+        "reply": "Reply",
+        "composeNewMessage": "Compose new message",
+        "subject": "Subject",
+        "message": "Message",
+        "send": "Send",
+        "close": "Close"
+      },
       "imagesBlocked": "Images in this email have been blocked.",
       "showImages": "Show Images"
     }

--- a/src/server/api/routers/participationEvents.ts
+++ b/src/server/api/routers/participationEvents.ts
@@ -50,8 +50,14 @@ export type EMailOpenReplyEvent = z.infer<typeof eMailOpenReplyEvent>;
 
 export const eMailSendReplyEvent = z.object({
   type: z.literal('email-send-reply'),
+  message: z.string(),
 });
 export type EMailSendReplyEvent = z.infer<typeof eMailSendReplyEvent>;
+
+export const eMailAbortReplyEvent = z.object({
+  type: z.literal('email-abort-reply'),
+});
+export type EMailSendReplyEvent = z.infer<typeof eMailAbortReplyEvent>;
 
 export const participationEvents = z.union([
   eMailViewEvent,
@@ -63,6 +69,7 @@ export const participationEvents = z.union([
   eMailLinkHoverEvent,
   eMailOpenReplyEvent,
   eMailSendReplyEvent,
+  eMailAbortReplyEvent,
 ]);
 export type ParticipationEvents = z.infer<typeof participationEvents>;
 

--- a/src/server/api/routers/participationEvents.ts
+++ b/src/server/api/routers/participationEvents.ts
@@ -43,6 +43,16 @@ export const eMailLinkHoverEvent = z.object({
 });
 export type EMailLinkHoverEvent = z.infer<typeof eMailLinkHoverEvent>;
 
+export const eMailWriteReplyEvent = z.object({
+  type: z.literal('email-write-reply'),
+});
+export type EMailWriteReplyEvent = z.infer<typeof eMailWriteReplyEvent>;
+
+export const eMailSendReplyEvent = z.object({
+  type: z.literal('email-send-reply'),
+});
+export type EMailSendReplyEvent = z.infer<typeof eMailSendReplyEvent>;
+
 export const participationEvents = z.union([
   eMailViewEvent,
   eMailViewDetailsEvent,
@@ -51,6 +61,8 @@ export const participationEvents = z.union([
   eMailScrolledEvent,
   eMailLinkClickEvent,
   eMailLinkHoverEvent,
+  eMailWriteReplyEvent,
+  eMailSendReplyEvent,
 ]);
 export type ParticipationEvents = z.infer<typeof participationEvents>;
 

--- a/src/server/api/routers/participationEvents.ts
+++ b/src/server/api/routers/participationEvents.ts
@@ -43,10 +43,10 @@ export const eMailLinkHoverEvent = z.object({
 });
 export type EMailLinkHoverEvent = z.infer<typeof eMailLinkHoverEvent>;
 
-export const eMailWriteReplyEvent = z.object({
-  type: z.literal('email-write-reply'),
+export const eMailOpenReplyEvent = z.object({
+	type: z.literal('email-open-reply'),
 });
-export type EMailWriteReplyEvent = z.infer<typeof eMailWriteReplyEvent>;
+export type EMailOpenReplyEvent = z.infer<typeof eMailOpenReplyEvent>;
 
 export const eMailSendReplyEvent = z.object({
   type: z.literal('email-send-reply'),
@@ -61,7 +61,7 @@ export const participationEvents = z.union([
   eMailScrolledEvent,
   eMailLinkClickEvent,
   eMailLinkHoverEvent,
-  eMailWriteReplyEvent,
+	eMailOpenReplyEvent,
   eMailSendReplyEvent,
 ]);
 export type ParticipationEvents = z.infer<typeof participationEvents>;

--- a/src/server/api/routers/participationEvents.ts
+++ b/src/server/api/routers/participationEvents.ts
@@ -44,7 +44,7 @@ export const eMailLinkHoverEvent = z.object({
 export type EMailLinkHoverEvent = z.infer<typeof eMailLinkHoverEvent>;
 
 export const eMailOpenReplyEvent = z.object({
-	type: z.literal('email-open-reply'),
+  type: z.literal('email-open-reply'),
 });
 export type EMailOpenReplyEvent = z.infer<typeof eMailOpenReplyEvent>;
 
@@ -61,7 +61,7 @@ export const participationEvents = z.union([
   eMailScrolledEvent,
   eMailLinkClickEvent,
   eMailLinkHoverEvent,
-	eMailOpenReplyEvent,
+  eMailOpenReplyEvent,
   eMailSendReplyEvent,
 ]);
 export type ParticipationEvents = z.infer<typeof participationEvents>;

--- a/src/server/api/routers/participationEvents.ts
+++ b/src/server/api/routers/participationEvents.ts
@@ -57,7 +57,7 @@ export type EMailSendReplyEvent = z.infer<typeof eMailSendReplyEvent>;
 export const eMailAbortReplyEvent = z.object({
   type: z.literal('email-abort-reply'),
 });
-export type EMailSendReplyEvent = z.infer<typeof eMailAbortReplyEvent>;
+export type EMailAbortReplyEvent = z.infer<typeof eMailAbortReplyEvent>;
 
 export const participationEvents = z.union([
   eMailViewEvent,


### PR DESCRIPTION
Participants can now click a reply button to open a popup, in which they can compose a reply and either send or abort. Three new events are now being tracked:
- `EMailOpenReplyEvent` triggers when the reply popup gets opened
- `EMailSendReplyEvent` triggers when the send button is clicked
- `EMailAbortReplyEvent` triggers when the popup is closed without sending