### PR TITLE
Release 2.0.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,12 +15,12 @@ services:
       timeout: 5s
       retries: 5
   app:
-    image: thorstenthiel/phishy-mailbox:v1.3.0
+    image: thorstenthiel/phishy-mailbox:v2.0.0
     build:
       context: .
       dockerfile: Dockerfile
       args:
-        VERSION: v1.3.0
+        VERSION: v2.0.0
     environment:
       DATABASE_URL: postgresql://mailbox:mailbox@postgres:5432/mailbox?schema=public
       NEXTAUTH_SECRET: secret1234256w5w4


### PR DESCRIPTION
## Release 2.0.0

Bumps the application image and `VERSION` build-arg in `docker-compose.yml` from `v1.3.0` to `v2.0.0`.

### ⚠️ Breaking change — PostgreSQL 15 → 17
The bundled database image moved across a major PostgreSQL version. Existing deployments require a **dump & restore** — see [UPGRADING.md](../blob/main/UPGRADING.md). This is why the release is a major version bump.

### Highlights since v1.3.0 (48 commits)
- Reply feature (write/send reply dialog, reply events & logging)
- Scheduled mails (`scheduledTime` on `StudyEmail` / `ParticipationEmail`)
- Expanded E2E test coverage & test-setup fixes
- Dependency upgrades (incl. Postgres 17)
- Various fixes: i18n hydration, folder email counts, favicon, linting/styling

### Release checklist
- [ ] Merge this PR to `main`
- [ ] Build & push Docker image `thorstenthiel/phishy-mailbox:v2.0.0`
- [ ] Create tag `v2.0.0` and GitHub release (link UPGRADING.md prominently)