### PR TITLE
Release 2.0.1

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,12 +15,12 @@ services:
       timeout: 5s
       retries: 5
   app:
-    image: thorstenthiel/phishy-mailbox:v2.0.0
+    image: thorstenthiel/phishy-mailbox:v2.0.1
     build:
       context: .
       dockerfile: Dockerfile
       args:
-        VERSION: v2.0.0
+        VERSION: v2.0.1
     environment:
       DATABASE_URL: postgresql://mailbox:mailbox@postgres:5432/mailbox?schema=public
       NEXTAUTH_SECRET: secret1234256w5w4


### PR DESCRIPTION
## Release 2.0.1

Patch release on top of 2.0.0.

### Included changes
- **Fix seeding in docker image entrypoint** (2da844c) — fixes seeding in the Docker standalone build (Prisma 7 / `@prisma/adapter-pg` ESM resolution).

### Release steps
- `docker-compose.yml`: bumped image tag and `VERSION` build arg to `v2.0.1`.

After merge, `v2.0.1` will be tagged.